### PR TITLE
security: add CodeQL and Dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    open-pull-requests-limit: 10
+    directory: /
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: gomod
+    open-pull-requests-limit: 10
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,30 @@
+name: CodeQL Advanced
+on:
+  workflow_dispatch:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+  schedule:
+    - cron: '15 7 * * 0'
+jobs:
+  actions:
+    uses: WebBeds/webbeds-reusable-workflows/.github/workflows/scan_actions.yml@main
+    permissions:
+      security-events: write
+      packages: read
+      actions: read
+      contents: read
+    secrets:
+      GIT_TOKEN: ${{ secrets.WEBBEDS_GIT_TOKEN }}
+
+  golang:
+    uses: WebBeds/webbeds-reusable-workflows/.github/workflows/scan_go.yml@main
+    permissions:
+      security-events: write
+      packages: read
+      actions: read
+      contents: read
+    secrets:
+      GIT_TOKEN: ${{ secrets.WEBBEDS_GIT_TOKEN }}
+


### PR DESCRIPTION
This PR adds:
- **CodeQL Advanced** jobs for the detected languages (Go and/or C#),
- **Terraform** scan if Terraform is present (HCL or .tf / terraform/),
- **Dependabot** for github-actions, and optionally terraform / gomod / NuGet.

Please review when you can. Thanks.